### PR TITLE
Fix remember me and password reset flows

### DIFF
--- a/frontend/lib/features/auth/screens/login_screen.dart
+++ b/frontend/lib/features/auth/screens/login_screen.dart
@@ -101,6 +101,7 @@ class _LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin
       final result = await _authService.login(
         _emailController.text.trim(),
         _passwordController.text,
+        rememberMe: _rememberMe,
       );
       setState(() => _loading = false);
       if (result.isSuccess) {

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -539,6 +539,11 @@ class AuthWrapper extends StatelessWidget {
         // Check if user is authenticated AND email confirmed
         final session = Supabase.instance.client.auth.currentSession;
         final user = Supabase.instance.client.auth.currentUser;
+        final event = snapshot.data?.event;
+
+        if (event == AuthChangeEvent.passwordRecovery) {
+          return const PasswordResetScreen();
+        }
         
         if (session != null && user != null) {
           // Check if this is a password reset session


### PR DESCRIPTION
## Summary
- respect the remember me checkbox when logging in
- detect password recovery events and route to the reset screen

## Testing
- `pytest`
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e369fe4c832dafe79d82be108059