### PR TITLE
Fix remember me and deep link handling

### DIFF
--- a/frontend/lib/features/auth/screens/login_screen.dart
+++ b/frontend/lib/features/auth/screens/login_screen.dart
@@ -67,11 +67,15 @@ class _LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin
 
   Future<void> _loadRememberedCredentials() async {
     final rememberedEmail = await _authService.getRememberedEmail();
+    final rememberedPassword = await _authService.getRememberedPassword();
     final hasRememberMe = await _authService.hasRememberMe();
-    
+
     if (rememberedEmail != null) {
       setState(() {
         _emailController.text = rememberedEmail;
+        if (rememberedPassword != null) {
+          _passwordController.text = rememberedPassword;
+        }
         _rememberMe = hasRememberMe;
       });
     }
@@ -101,6 +105,7 @@ class _LoginScreenState extends State<LoginScreen> with TickerProviderStateMixin
       final result = await _authService.login(
         _emailController.text.trim(),
         _passwordController.text,
+        rememberMe: _rememberMe,
       );
       setState(() => _loading = false);
       if (result.isSuccess) {

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -94,14 +94,16 @@ class _DiabetesMeAppState extends State<DiabetesMeApp> {
     print('🔗 Processing deep link: $uri');
     print('🔗 Scheme: ${uri.scheme}, Host: ${uri.host}');
     print('🔗 Query parameters: ${uri.queryParameters}');
-    
+
     if (uri.scheme == 'com.abhinavsrinivasan.diabetesme') {
-      if (uri.host == 'login-callback') {
+      final type = uri.queryParameters['type'];
+
+      if (type == 'recovery' || uri.host == 'password-reset') {
+        // Handle password reset regardless of host when type is recovery
+        await _handlePasswordReset(uri);
+      } else if (uri.host == 'login-callback') {
         // Handle email confirmation
         await _handleEmailConfirmation(uri);
-      } else if (uri.host == 'password-reset') {
-        // Handle password reset
-        await _handlePasswordReset(uri);
       }
     }
   }
@@ -539,6 +541,11 @@ class AuthWrapper extends StatelessWidget {
         // Check if user is authenticated AND email confirmed
         final session = Supabase.instance.client.auth.currentSession;
         final user = Supabase.instance.client.auth.currentUser;
+        final event = snapshot.data?.event;
+
+        if (event == AuthChangeEvent.passwordRecovery) {
+          return const PasswordResetScreen();
+        }
         
         if (session != null && user != null) {
           // Check if this is a password reset session


### PR DESCRIPTION
## Summary
- persist passwords when remembering login credentials
- detect recovery deep links and route to reset screen

## Testing
- `pytest`
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e369fe4c832dafe79d82be108059